### PR TITLE
feat(frontend): consume aggregated /api/workflows and render grouped results

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -22,15 +22,17 @@ const mockWorkflowRuns = [
   }
 ];
 
-const mockApiResponse = {
-  workflow_runs: mockWorkflowRuns
+const mockAggregatedResponse = {
+  results: [
+    { repo: 'octocat/Hello-World', runs: mockWorkflowRuns },
+  ],
 };
 
 beforeEach(() => {
   mockFetch.mockClear();
   mockFetch.mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve(mockApiResponse)
+    json: () => Promise.resolve(mockAggregatedResponse)
   });
 });
 
@@ -58,7 +60,7 @@ test('loads and displays workflows', async () => {
   expect(screen.getAllByText(/Conclusion:/)).toHaveLength(2);
 
   // Verify fetch was called with correct URL
-  expect(mockFetch).toHaveBeenCalledWith('/api/repos/octocat/Hello-World/actions/runs', {
+  expect(mockFetch).toHaveBeenCalledWith('/api/workflows?repos=octocat%2FHello-World', {
     signal: expect.any(AbortSignal)
   });
 });


### PR DESCRIPTION
This pull request updates the frontend to consume a new aggregated workflows API endpoint and adjusts the UI and tests to handle the new response format. The main changes involve fetching and displaying workflow runs grouped by repository, and updating the tests to match the new API contract.

**Frontend API integration and UI updates:**

* Refactored the workflow fetching logic in `App.js` to call the new `/api/workflows?repos=...` endpoint, passing repositories as a query parameter, and updated the expected response shape to `{ results: [ { repo, runs }, ... ] }`. [[1]](diffhunk://#diff-4e185b456927ee5c9781afdfbd5054b8cfb34c5b099a169c2bab8c822931625cL17-R19) [[2]](diffhunk://#diff-4e185b456927ee5c9781afdfbd5054b8cfb34c5b099a169c2bab8c822931625cL28-L53)
* Updated the rendering logic to display workflow runs grouped by repository, including handling empty results for a repository.

**Test updates:**

* Modified the mock API response in `App.test.js` to match the new aggregated format and updated the fetch URL expectation accordingly. [[1]](diffhunk://#diff-3c5fe99173ea5f0f99095e97633cf680f1246ce649353f813a5a9ca18df0e82aL25-R35) [[2]](diffhunk://#diff-3c5fe99173ea5f0f99095e97633cf680f1246ce649353f813a5a9ca18df0e82aL61-R63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Workflow runs are now grouped by repository for easier browsing.
  - Faster, more consistent loading of workflows across repositories.
  - Each repository section shows run name, status, conclusion (with N/A when unavailable), and created date.
  - Clear placeholder appears when a repository has no runs.
  - Improved error messaging when loading workflows fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->